### PR TITLE
Fix GCC6+ inline semantics; memory.c to globals.h.

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -150,8 +150,35 @@ int keyboard_checkforkeypress(int keycode);
 /* memory.c */
 int memory_init(int memorysize);
 void memory_destroy(void);
-inline void memory_write(register word address, register byte value);
-inline byte memory_read(register int address);
+
+/**
+ * Attempts to read one byte of memory at the requested address. Returns the 
+ * byte read from memory.
+ *
+ * @param address the address in memory to read from
+ * @return the value read from the specified memory location
+ */
+static inline byte 
+memory_read(register int address) 
+{
+   return memory[address];
+}
+
+/*****************************************************************************/
+
+/**
+ * Attempts to write one byte of information to the requested address.
+ *
+ * @param address the address in memory to write to
+ * @param value the value to write to the memory location
+ */
+static inline void 
+memory_write(register word address, register byte value) 
+{
+   memory[address.WORD] = value;
+}
+
+/*****************************************************************************/
 
 /* screen.c */
 int screen_init(void);

--- a/memory.c
+++ b/memory.c
@@ -40,35 +40,6 @@ memory_init(int memorysize)
 /*****************************************************************************/
 
 /**
- * Attempts to read one byte of memory at the requested address. Returns the 
- * byte read from memory.
- *
- * @param address the address in memory to read from
- * @return the value read from the specified memory location
- */
-inline byte 
-memory_read(register int address) 
-{
-   return memory[address];
-}
-
-/*****************************************************************************/
-
-/**
- * Attempts to write one byte of information to the requested address.
- *
- * @param address the address in memory to write to
- * @param value the value to write to the memory location
- */
-inline void 
-memory_write(register word address, register byte value) 
-{
-   memory[address.WORD] = value;
-}
-
-/*****************************************************************************/
-
-/**
  * Frees the emulator memory.
  */
 void 


### PR DESCRIPTION
The semantics used for declaring the inline functions in memory.c (memory_read() and memory_write()), and then prototyping them in globals.h are invalid; the code is accepted by at least GCC < 5, but is rejected by GCC 6+. As inline functions are supposed to be defined wherever they are declared, the fix is to move the inline into globals.h and to make them static, thus allowing the program to compile on both GCC versions < 5 and 6+.

reference: http://en.cppreference.com/w/c/language/inline
