### PR TITLE
Add codecov support and badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,11 @@ before_install:
   - cd ..
 
 script:
-  - make test
+  - CFLAGS="-coverage -O0 -Wall -fprofile-arcs -ftest-coverage" make test
+  - gcov cpu.c
+  - gcov screen.c
+  - gcov keyboard.c
+  - gcov memory.c
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,8 @@ doc:
 
 clean:
 	@- $(RM) $(wildcard *.o)
+	@- $(RM) $(wildcard *.gcda)
+	@- $(RM) $(wildcard *.gcno)
+	@- $(RM) $(wildcard *.gcov)
 	@- $(RM) $(NAME)
 	@- $(RM) $(TESTNAME)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Yet Another Chip 8 Emulator
 
 [![Build Status](https://travis-ci.org/craigthomas/Chip8C.svg?branch=master&style=flat)](https://travis-ci.org/craigthomas/Chip8C) 
+[![codecov](https://codecov.io/gh/craigthomas/Chip8C/branch/master/graph/badge.svg)](https://codecov.io/gh/craigthomas/Chip8C) 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/befe98f4b3a044a9a0df49aa0fcaf35a)](https://www.codacy.com/app/craig-thomas/Chip8C?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=craigthomas/Chip8C&amp;utm_campaign=Badge_Grade)
 
 ## Table of Contents


### PR DESCRIPTION
This PR adds codecov support to the project. It modifies the Travis YAML file to include additional `CFLAGS` to support `gcov` coverage reporting. The file then sends the result to codecov. Status badge added to the `README.md` file. The make `clean` target has been updated to remove any unnecessary code coverage report files.