### PR TITLE
Make keyboard keys line up with Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,10 @@ different mode of operation. The debug keys are:
 | Keyboard Key | Effect |
 | :----------: | ------ |
 | `ESC`        | Quits the emulator             |
-| `F2`         | Enters CPU trace mode          |
-| `F1`         | Enters CPU trace and step mode |
-| `->`         | Next key while in step mode    |
-| `F12`        | Exits CPU trace or step mode   |
+| `X`          | Enters CPU trace mode          |
+| `Z`          | Enters CPU trace and step mode |
+| `N`          | Next key while in step mode    |
+| `C`          | Exits CPU trace or step mode   |
 
 ## ROM Compatibility
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -53,10 +53,10 @@
 
 /* Keyboard special keys */
 #define QUIT_KEY   SDLK_ESCAPE /**< Quits the emulator                        */
-#define DEBUG_KEY  SDLK_F1     /**< Puts emulator into debug mode             */
-#define TRACE_KEY  SDLK_F2     /**< Puts emulator into trace mode             */
-#define NORMAL_KEY SDLK_F12    /**< Returns emulator to normal running mode   */
-#define STEP_KEY   SDLK_RIGHT  /**< Runs next instruction (in debug mode)     */
+#define DEBUG_KEY  SDLK_z      /**< Puts emulator into debug mode             */
+#define TRACE_KEY  SDLK_x      /**< Puts emulator into trace mode             */
+#define NORMAL_KEY SDLK_c      /**< Returns emulator to normal running mode   */
+#define STEP_KEY   SDLK_n      /**< Runs next instruction (in debug mode)     */
 
 /* Other generic definitions */
 #define TRUE          1


### PR DESCRIPTION
This PR changes the debug key definitions to match up with the definitions from the [Chip8Java](https://github.com/craigthomas/Chip8Java) version of the emulator. README updated to reflect keyboard changes.