### PR TITLE
Remap keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,40 +153,31 @@ keys.
 ### Regular Keys
 
 The original Chip 8 had a keypad with the numbered keys 0 - 9 and A - F (16
-keys in total). Without any modifications to the emulator, the keys are mapped
-as follows:
+keys in total). The original key configuration was as follows:
 
-| Chip 8 Key | Keyboard Key |
-| :--------: | :----------: |
-| `1`        | `4`          |
-| `2`        | `5`          |
-| `3`        | `6`          |
-| `4`        | `7`          |
-| `5`        | `R`          |
-| `6`        | `T`          |
-| `7`        | `Y`          |
-| `8`        | `U`          |
-| `9`        | `F`          |
-| `0`        | `G`          |
-| `A`        | `H`          |
-| `B`        | `J`          |
-| `C`        | `V`          |
-| `D`        | `B`          |
-| `E`        | `N`          |
-| `F`        | `M`          |
+
+| `1` | `2` | `3` | `C` |
+|-----|-----|-----|-----|
+| `4` | `5` | `6` | `D` |
+| `7` | `8` | `9` | `E` |
+| `A` | `0` | `B` | `F` |
+
+The Chip8 emulator maps them to the following keyboard keys by default:
+
+| `1` | `2` | `3` | `4` |
+|-----|-----|-----|-----|
+| `Q` | `W` | `E` | `R` |
+| `A` | `S` | `D` | `F` |
+| `Z` | `X` | `C` | `V` |
 
 ### Debug Keys
 
-Pressing a debug key at any time will cause the emulator to enter into a
-different mode of operation. The debug keys are:
+In addition to the key mappings specified in the configuration file, there are additional
+keys that impact the execution of the emulator.
 
-| Keyboard Key | Effect |
-| :----------: | ------ |
-| `ESC`        | Quits the emulator             |
-| `X`          | Enters CPU trace mode          |
-| `Z`          | Enters CPU trace and step mode |
-| `N`          | Next key while in step mode    |
-| `C`          | Exits CPU trace or step mode   |
+| Keyboard Key | Effect             |
+| :----------: |--------------------|
+| `ESC`        | Quits the emulator |
 
 ## ROM Compatibility
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Craig Thomas
+ * Copyright (C) 2012-2024 Craig Thomas
  * This project uses an MIT style license - see the LICENSE file for details.
  *
  * @file      globals.h
@@ -41,6 +41,7 @@ SDL_TimerID cpu_timer;         /**< A CPU tick timer                          */
 unsigned long cpu_interrupt;   /**< The CPU interrupt routine                 */
 int decrement_timers;          /**< Flags CPU to decrement DELAY and SOUND    */
 int op_delay;                  /**< Millisecond delay on the CPU              */
+int awaiting_keypress;         /**< Whether to wait for a keypress event      */
 
 /* Event captures */
 SDL_Event event;               /**< Stores SDL events                         */

--- a/src/globals.h
+++ b/src/globals.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Craig Thomas
+ * Copyright (C) 2012-2024 Craig Thomas
  * This project uses an MIT style license - see the LICENSE file for details.
  *
  * @file      globals.h
@@ -48,7 +48,7 @@
 #define KEY_BUFFERSIZE   8    /**< Number of keys to store in the buffer      */
 #define KEY_DEBUG        1    /**< Only accept debug keystrokes               */
 #define KEY_NORMAL       0    /**< Accept normal keystrokes                   */
-#define KEY_NUMBEROFKEYS 15   /**< Defines the number of keys on the keyboard */
+#define KEY_NUMBEROFKEYS 16   /**< Defines the number of keys on the keyboard */
 #define KEY_NOKEY        -999 /**< Sets the no keypress value                 */
 
 /* Keyboard special keys */
@@ -81,14 +81,6 @@ typedef union {
       #endif
    } BYTE;
 } word;
-
-/**
- * Maps an SDLKey symbol to a keycode. 
- */
-typedef struct {
-   int keycode;        /**< The Chip 8 keycode value of the key               */
-   SDLKey symbol;      /**< The corresponding SDL symbol value of the key     */
-} KEYSPEC;
 
 /**
  * The chip8regset structure represents a Chip 8 cpu. Each of the major 
@@ -136,6 +128,7 @@ extern SDL_TimerID cpu_timer;         /**< A CPU tick timer                     
 extern unsigned long cpu_interrupt;   /**< The CPU interrupt routine                 */
 extern int decrement_timers;          /**< Flags CPU to decrement DELAY and SOUND    */
 extern int op_delay;                  /**< Millisecond delay on the CPU              */
+extern int awaiting_keypress;         /**< Whether to wait for a keypress event      */
 
 /* Event captures */
 extern SDL_Event event;               /**< Stores SDL events                         */
@@ -151,10 +144,6 @@ void cpu_reset(void);
 int cpu_timerinit(void);
 void cpu_execute(void);
 void cpu_execute_single(void);
-
-/* keyboard.c */
-int keyboard_waitgetkeypress(void);
-int keyboard_checkforkeypress(int keycode);
 
 /* memory.c */
 int memory_init(int memorysize);
@@ -221,8 +210,10 @@ int screen_get_height(void);
 int screen_get_width(void);
 
 /* keyboard.c */
-SDLKey keyboard_keycodetosymbol(int keycode);
-int keyboard_symboltokeycode(SDLKey symbol);
+int keyboard_isemulatorkey(SDLKey key);
+int keyboard_checkforkeypress(int keycode);
+void keyboard_processkeydown(SDLKey key);
+void keyboard_processkeyup(SDLKey key);
 
 /* cpu_test.c */
 void test_jump_to_address(void);
@@ -277,11 +268,10 @@ void test_screen_scroll_left(void);
 void test_screen_scroll_down(void);
 
 /* keyboard_test.c */
-void test_keycodetosymbol_returns_end_with_invalid_keycode(void);
-void test_keycodetosymbol_returns_correct_keycodes(void);
-void test_keyboard_symboltokeycode_returns_nokey_on_invalid_symbol(void);
-void test_keyboard_symboltokeycode_returns_correct_keycodes(void);
 void test_keyboard_checkforkeypress_returns_false_on_no_keypress(void);
+void test_keyboard_process_keydown(void);
+void test_keyboard_process_keyup(void);
+void test_keyboard_isemulatorkey(void);
 
 #endif
 

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Craig Thomas
+ * Copyright (C) 2012-2024 Craig Thomas
  * This project uses an MIT style license - see the LICENSE file for details.
  *
  * @file      keyboard.c
@@ -37,70 +37,49 @@
 /*!
  * Keyboard mapping from SDL keys to key values 
  */
-KEYSPEC keyboard_def[] = 
+SDLKey keyboard_def[] = 
 {
-   { 0x1, SDLK_4 },
-   { 0x2, SDLK_5 },
-   { 0x3, SDLK_6 },
-   { 0x4, SDLK_r },
-   { 0x5, SDLK_t },
-   { 0x6, SDLK_y },
-   { 0x7, SDLK_f },
-   { 0x8, SDLK_g },
-   { 0x9, SDLK_h },
-   { 0xA, SDLK_v },
-   { 0xB, SDLK_b },
-   { 0xC, SDLK_7 },
-   { 0xD, SDLK_u },
-   { 0xE, SDLK_j },
-   { 0xF, SDLK_n }
+    SDLK_x,
+    SDLK_1,
+    SDLK_2,
+    SDLK_3,
+    SDLK_q,
+    SDLK_w,
+    SDLK_e,
+    SDLK_a,
+    SDLK_s,
+    SDLK_d,
+    SDLK_z,
+    SDLK_c,
+    SDLK_4,
+    SDLK_r,
+    SDLK_f,
+    SDLK_v
+};
+
+/*!
+ * The state of the pressed keys on the keyboard
+ */
+int keyboard_state[] = {
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE, 
+    FALSE
 };
 
 /* F U N C T I O N S **********************************************************/
-
-/**
- * Takes a keycode and returns the associated SDLKey mapping. Returns SDLK_END 
- * on no match.
- *
- * @param keycode the keycode to check for
- * @return the SDLKey that is associated with the keycode
- */
-SDLKey 
-keyboard_keycodetosymbol(int keycode)
-{
-    int i;
-
-    for (i = 0; i < KEY_NUMBEROFKEYS; i++) {
-        if (keyboard_def[i].keycode == keycode) {
-            return keyboard_def[i].symbol;
-        }
-    }
-    return SDLK_END;
-}
-
-/******************************************************************************/
-
-/**
- * Takes the SDLKey symbol and checks to see if there is an associated keycode. 
- * Returns KEY_NOKEY on no match.
- *
- * @param symbol the SDLKey to check
- * @return the associated keycode, or KEY_NOKEY if no key mapping exists
- */
-int 
-keyboard_symboltokeycode(SDLKey symbol)
-{
-    int i;
-
-    for (i = 0; i < KEY_NUMBEROFKEYS; i++) {
-        if (keyboard_def[i].symbol == symbol) {
-            return keyboard_def[i].keycode;
-        }
-    }
-    return KEY_NOKEY;
-}
-
-/******************************************************************************/
 
 /**
  * Checks to see whether or not the specified keycode was pressed. Returns 
@@ -112,33 +91,65 @@ keyboard_symboltokeycode(SDLKey symbol)
 int 
 keyboard_checkforkeypress(int keycode)
 {
-    Uint8 *keystates = SDL_GetKeyState(NULL);
-    return keystates[keyboard_keycodetosymbol(keycode)];
+    if (keycode >= 0 && keycode < KEY_NUMBEROFKEYS) {
+        return keyboard_state[keycode];
+    }
+    return FALSE;
 }
 
 /******************************************************************************/
 
 /**
- * Wait and loop until a key is pressed. Returns the keycode of the key that 
- * was pressed, or 0 on failure.
- *
- * @return the keycode value of the key pressed
+ * If the key pressed is a valid emulator key, will return the key encoding 
+ * for that key pressed, or -1 if the key is not a valid emulator key
+ * 
+ * @param key the SDLKey to check
+ * @return the value of the key if it is an emulator key, -1 otherwise
  */
-int 
-keyboard_waitgetkeypress(void)
+int
+keyboard_isemulatorkey(SDLKey key)
 {
-    while (TRUE) {
-        if (SDL_PollEvent(&event)) {
-            switch (event.type) {
-                case SDL_KEYDOWN:
-                    return keyboard_symboltokeycode(event.key.keysym.sym);
-                    break;
-
-                default:
-                    break;
-            }
+    for (int x=0; x < KEY_NUMBEROFKEYS; x++) {
+        if (key == keyboard_def[x]) {
+            return x;
         }
-        SDL_Delay(20);
+    }
+    return -1;
+}
+
+/******************************************************************************/
+
+/**
+ * Processes a keypress. Will check to see what key was pressed, and sets the
+ * corresponding keypress state in the keyboard matrix to TRUE.
+ * 
+ * @param key the SDLKey to process
+ */
+void
+keyboard_processkeydown(SDLKey key) 
+{
+    for (int x=0; x < KEY_NUMBEROFKEYS; x++) {
+        if (key == keyboard_def[x]) {
+            keyboard_state[x] = TRUE;
+        }
+    }
+}
+
+/******************************************************************************/
+
+/**
+ * Processes a key release. Will check to see what key was released, and sets the
+ * corresponding keypress state in the keyboard matrix to FALSE.
+ * 
+ * @param key the SDLKey to process
+ */
+void
+keyboard_processkeyup(SDLKey key) 
+{
+    for (int x=0; x < KEY_NUMBEROFKEYS; x++) {
+        if (key == keyboard_def[x]) {
+            keyboard_state[x] = FALSE;
+        }
     }
 }
 

--- a/src/keyboard_test.c
+++ b/src/keyboard_test.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012-2019 Craig Thomas
+ * Copyright (C) 2012-2024 Craig Thomas
  * This project uses an MIT style license - see the LICENSE file for details.
  *
  * @file      screen_test.c
@@ -14,64 +14,122 @@
 
 /* F U N C T I O N S **********************************************************/
 
-void
-test_keycodetosymbol_returns_end_with_invalid_keycode(void) 
-{
-    SDLKey result = keyboard_keycodetosymbol(0x10);
-    CU_ASSERT_EQUAL(SDLK_END, result);
-}
-
-void
-test_keycodetosymbol_returns_correct_keycodes(void) 
-{
-    CU_ASSERT_EQUAL(SDLK_4, keyboard_keycodetosymbol(0x1));
-    CU_ASSERT_EQUAL(SDLK_5, keyboard_keycodetosymbol(0x2));
-    CU_ASSERT_EQUAL(SDLK_6, keyboard_keycodetosymbol(0x3));
-    CU_ASSERT_EQUAL(SDLK_r, keyboard_keycodetosymbol(0x4));
-    CU_ASSERT_EQUAL(SDLK_t, keyboard_keycodetosymbol(0x5));
-    CU_ASSERT_EQUAL(SDLK_y, keyboard_keycodetosymbol(0x6));
-    CU_ASSERT_EQUAL(SDLK_f, keyboard_keycodetosymbol(0x7));
-    CU_ASSERT_EQUAL(SDLK_g, keyboard_keycodetosymbol(0x8));
-    CU_ASSERT_EQUAL(SDLK_h, keyboard_keycodetosymbol(0x9));
-    CU_ASSERT_EQUAL(SDLK_v, keyboard_keycodetosymbol(0xA));
-    CU_ASSERT_EQUAL(SDLK_b, keyboard_keycodetosymbol(0xB));
-    CU_ASSERT_EQUAL(SDLK_7, keyboard_keycodetosymbol(0xC));
-    CU_ASSERT_EQUAL(SDLK_u, keyboard_keycodetosymbol(0xD));
-    CU_ASSERT_EQUAL(SDLK_j, keyboard_keycodetosymbol(0xE));
-    CU_ASSERT_EQUAL(SDLK_n, keyboard_keycodetosymbol(0xF));
-}
-
-void 
-test_keyboard_symboltokeycode_returns_nokey_on_invalid_symbol(void)
-{
-    int result = keyboard_symboltokeycode(SDLK_z);
-    CU_ASSERT_EQUAL(KEY_NOKEY, result);
-}
-
-void 
-test_keyboard_symboltokeycode_returns_correct_keycodes(void)
-{
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_4), 0x1);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_5), 0x2);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_6), 0x3);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_r), 0x4);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_t), 0x5);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_y), 0x6);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_f), 0x7);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_g), 0x8);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_h), 0x9);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_v), 0xA);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_b), 0xB);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_7), 0xC);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_u), 0xD);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_j), 0xE);
-    CU_ASSERT_EQUAL(keyboard_symboltokeycode(SDLK_n), 0xF);
-}
-
 void 
 test_keyboard_checkforkeypress_returns_false_on_no_keypress(void)
 {
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x0));
     CU_ASSERT_FALSE(keyboard_checkforkeypress(0x1));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x2));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x3));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x4));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x5));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x6));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x7));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x8));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x9));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xA));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xB));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xC));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xD));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xE));
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xF));
+}
+
+void
+test_keyboard_process_keydown(void) 
+{
+    keyboard_processkeydown(SDLK_x);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0x0));
+    keyboard_processkeydown(SDLK_1);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0x1));
+    keyboard_processkeydown(SDLK_2);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0x2));
+    keyboard_processkeydown(SDLK_3);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0x3));
+    keyboard_processkeydown(SDLK_q);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0x4));
+    keyboard_processkeydown(SDLK_w);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0x5));
+    keyboard_processkeydown(SDLK_e);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0x6));
+    keyboard_processkeydown(SDLK_a);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0x7));
+    keyboard_processkeydown(SDLK_s);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0x8));
+    keyboard_processkeydown(SDLK_d);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0x9));
+    keyboard_processkeydown(SDLK_z);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0xA));
+    keyboard_processkeydown(SDLK_c);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0xB));
+    keyboard_processkeydown(SDLK_4);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0xC));
+    keyboard_processkeydown(SDLK_r);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0xD));
+    keyboard_processkeydown(SDLK_f);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0xE));
+    keyboard_processkeydown(SDLK_v);
+    CU_ASSERT_TRUE(keyboard_checkforkeypress(0xF));
+}
+
+void
+test_keyboard_process_keyup(void) 
+{
+    keyboard_processkeydown(SDLK_x);
+    keyboard_processkeyup(SDLK_x);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x0));
+    keyboard_processkeydown(SDLK_1);
+    keyboard_processkeyup(SDLK_1);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x1));
+    keyboard_processkeydown(SDLK_2);
+    keyboard_processkeyup(SDLK_2);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x2));
+    keyboard_processkeydown(SDLK_3);
+    keyboard_processkeyup(SDLK_3);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x3));
+    keyboard_processkeydown(SDLK_q);
+    keyboard_processkeyup(SDLK_q);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x4));
+    keyboard_processkeydown(SDLK_w);
+    keyboard_processkeyup(SDLK_w);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x5));
+    keyboard_processkeydown(SDLK_e);
+    keyboard_processkeyup(SDLK_e);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x6));
+    keyboard_processkeydown(SDLK_a);
+    keyboard_processkeyup(SDLK_a);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x7));
+    keyboard_processkeydown(SDLK_s);
+    keyboard_processkeyup(SDLK_s);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x8));
+    keyboard_processkeydown(SDLK_d);
+    keyboard_processkeyup(SDLK_d);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0x9));
+    keyboard_processkeydown(SDLK_z);
+    keyboard_processkeyup(SDLK_z);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xA));
+    keyboard_processkeydown(SDLK_c);
+    keyboard_processkeyup(SDLK_c);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xB));
+    keyboard_processkeydown(SDLK_4);
+    keyboard_processkeyup(SDLK_4);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xC));
+    keyboard_processkeydown(SDLK_r);
+    keyboard_processkeyup(SDLK_r);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xD));
+    keyboard_processkeydown(SDLK_f);
+    keyboard_processkeyup(SDLK_f);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xE));
+    keyboard_processkeydown(SDLK_v);
+    keyboard_processkeyup(SDLK_v);
+    CU_ASSERT_FALSE(keyboard_checkforkeypress(0xF));
+}
+
+void
+test_keyboard_isemulatorkey(void)
+{
+    CU_ASSERT_EQUAL(-1, keyboard_isemulatorkey(SDLK_k));
+    CU_ASSERT_EQUAL(1, keyboard_isemulatorkey(SDLK_1));
 }
 
 /* E N D   O F   F I L E *****************************************************/

--- a/src/test.c
+++ b/src/test.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Craig Thomas
+ * Copyright (C) 2019-2024 Craig Thomas
  * This project uses an MIT style license - see the LICENSE file for details.
  *
  * @file      test.c
@@ -93,11 +93,10 @@ main() {
         return CU_get_error();
     }
 
-    if (CU_add_test(keyboard_suite, "test_keycodetosymbol_returns_end_with_invalid_keycode", test_keycodetosymbol_returns_end_with_invalid_keycode) == NULL ||
-        CU_add_test(keyboard_suite, "test_keycodetosymbol_returns_correct_keycodes", test_keycodetosymbol_returns_correct_keycodes) == NULL ||
-        CU_add_test(keyboard_suite, "test_keyboard_symboltokeycode_returns_nokey_on_invalid_symbol", test_keyboard_symboltokeycode_returns_nokey_on_invalid_symbol) == NULL ||
-        CU_add_test(keyboard_suite, "test_keyboard_symboltokeycode_returns_correct_keycodes", test_keyboard_symboltokeycode_returns_correct_keycodes) == NULL ||
-        CU_add_test(keyboard_suite, "test_keyboard_checkforkeypress_returns_false_on_no_keypress", test_keyboard_checkforkeypress_returns_false_on_no_keypress) == NULL)
+    if (CU_add_test(keyboard_suite, "test_keyboard_checkforkeypress_returns_false_on_no_keypress", test_keyboard_checkforkeypress_returns_false_on_no_keypress) == NULL ||
+        CU_add_test(keyboard_suite, "test_keyboard_process_keydown", test_keyboard_process_keydown) == NULL ||
+        CU_add_test(keyboard_suite, "test_keyboard_process_keyup", test_keyboard_process_keyup) == NULL ||
+        CU_add_test(keyboard_suite, "test_keyboard_isemulatorkey", test_keyboard_isemulatorkey) == NULL)
     {
         CU_cleanup_registry();
         return CU_get_error();


### PR DESCRIPTION
This PR remaps the emulated keyboard to align with the keyboard layout proposed by the Octo interpreter. It also simplifies the keymapping structure, and removes many of the debug keys (debug trace and step functions along with the debug overlay will be removed in a future PR). Unit tests updated to match new functionality. This PR closes #31 