### PR TITLE
Make emulator memory size default to 64K

### DIFF
--- a/src/cpu_test.c
+++ b/src/cpu_test.c
@@ -17,7 +17,7 @@
 void 
 setup(void) 
 {
-    CU_TEST_FATAL(memory_init(MEM_4K));
+    CU_TEST_FATAL(memory_init(MEM_SIZE));
     cpu_reset();
 }
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -20,9 +20,9 @@
 /* D E F I N E S **************************************************************/
 
 /* Memory */
-#define MEM_4K         0x1000    /**< Defines a 4K memory size                */
+#define MEM_SIZE       0x10000   /**< Defines a 64K memory size               */
 #define SP_START       0x52      /**< Defines the start of the system stack   */
-#define ROM_DEFAULT    0x200	 /**< Defines the default ROM load point        */
+#define ROM_DEFAULT    0x200	   /**< Defines the default ROM load point      */
 
 /* Screen */
 #define SCREEN_HEIGHT      32    /**< Default screen height                   */

--- a/src/yac8e.c
+++ b/src/yac8e.c
@@ -172,7 +172,7 @@ main(int argc, char **argv)
         exit(1);
     }
 
-    if (!memory_init(MEM_4K)) {
+    if (!memory_init(MEM_SIZE)) {
         printf ("Fatal: Unable to allocate emulator memory\n");
         SDL_Quit ();
         exit (1);


### PR DESCRIPTION
This PR changes the default memory size to 64K for use with XO chip programs. This PR closes #15 