### PR TITLE
Make screen window constant size

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -256,14 +256,14 @@ cpu_execute_single(void)
                 /* 00FE - EXTD */
                 /* Disable extended mode */
                 case 0xFE:
-                    screen_disable_extended();
+                    screen_set_normal_mode();
                     sprintf(cpu.opdesc, "EXTD");
                     break;
 
                 /* 00FF - EXTE */
                 /* Enable extended mode */
                 case 0xFF:
-                    screen_set_extended();
+                    screen_set_extended_mode();
                     sprintf(cpu.opdesc, "EXTE");
                     break;
 
@@ -539,7 +539,7 @@ cpu_execute_single(void)
             tbyte = cpu.operand.BYTE.low & 0xF;
             cpu.v[0xF] = 0;
 
-            if (screen_extended_mode && tbyte == 0) {
+            if (screen_is_extended_mode() && tbyte == 0) {
                 for (i = 0; i < 16; i++) {
                     for (k = 0; k < 2; k++) {
                         tbyte = memory_read(cpu.i.WORD + (i * 2) + k);
@@ -551,7 +551,7 @@ cpu_execute_single(void)
                             xcor = xcor % screen_get_width();
 
                             color = (tbyte & 0x80) ? 1 : 0;
-                            currentcolor = screen_getpixel(xcor, ycor);
+                            currentcolor = screen_get_pixel(xcor, ycor);
 
                             cpu.v[0xF] = (currentcolor && color) ? 1 : cpu.v[0xF];
                             color = color ^ currentcolor;
@@ -574,7 +574,7 @@ cpu_execute_single(void)
                         xcor = xcor % screen_get_width();
 
                         color = (tbyte & 0x80) ? 1 : 0;
-                        currentcolor = screen_getpixel(xcor, ycor);
+                        currentcolor = screen_get_pixel(xcor, ycor);
 
                         cpu.v[0xF] = (currentcolor && color) ? 1 : cpu.v[0xF];
                         color = color ^ currentcolor;

--- a/src/cpu_test.c
+++ b/src/cpu_test.c
@@ -676,14 +676,14 @@ test_cpu_scroll_left(void)
     setup();
     setup_cpu_screen_test();
     screen_draw(5, 1, 1);
-    CU_ASSERT_TRUE(screen_getpixel(5, 1));
+    CU_ASSERT_TRUE(screen_get_pixel(5, 1));
     tword.WORD = 0x00FC;
     address.WORD = 0x0000;
     memory_write_word(address, tword);
     cpu.pc.WORD = 0x0000;
     cpu_execute_single();
-    CU_ASSERT_FALSE(screen_getpixel(5, 1));
-    CU_ASSERT_TRUE(screen_getpixel(1, 1));
+    CU_ASSERT_FALSE(screen_get_pixel(5, 1));
+    CU_ASSERT_TRUE(screen_get_pixel(1, 1));
     teardown();
     teardown_cpu_screen_test();
 }
@@ -694,14 +694,14 @@ test_cpu_scroll_right(void)
     setup();
     setup_cpu_screen_test();
     screen_draw(1, 1, 1);
-    CU_ASSERT_TRUE(screen_getpixel(1, 1));
+    CU_ASSERT_TRUE(screen_get_pixel(1, 1));
     tword.WORD = 0x00FB;
     address.WORD = 0x0000;
     memory_write_word(address, tword);
     cpu.pc.WORD = 0x0000;
     cpu_execute_single();
-    CU_ASSERT_FALSE(screen_getpixel(1, 1));
-    CU_ASSERT_TRUE(screen_getpixel(5, 1));
+    CU_ASSERT_FALSE(screen_get_pixel(1, 1));
+    CU_ASSERT_TRUE(screen_get_pixel(5, 1));
     teardown();
     teardown_cpu_screen_test();
 }
@@ -712,14 +712,14 @@ test_cpu_scroll_down(void)
     setup();
     setup_cpu_screen_test();
     screen_draw(1, 5, 1);
-    CU_ASSERT_TRUE(screen_getpixel(1, 5));
+    CU_ASSERT_TRUE(screen_get_pixel(1, 5));
     tword.WORD = 0x00C4;
     address.WORD = 0x0000;
     memory_write_word(address, tword);
     cpu.pc.WORD = 0x0000;
     cpu_execute_single();
-    CU_ASSERT_FALSE(screen_getpixel(1, 5));
-    CU_ASSERT_TRUE(screen_getpixel(1, 9));
+    CU_ASSERT_FALSE(screen_get_pixel(1, 5));
+    CU_ASSERT_TRUE(screen_get_pixel(1, 9));
     teardown();
     teardown_cpu_screen_test();
 }
@@ -737,7 +737,7 @@ test_cpu_screen_blank(void)
 
     for (int x = 0; x < screen_get_width(); x++) {
         for (int y = 0; y < screen_get_height(); y++) {
-            CU_ASSERT_TRUE(screen_getpixel(x, y));
+            CU_ASSERT_TRUE(screen_get_pixel(x, y));
         }
     }
 
@@ -749,7 +749,7 @@ test_cpu_screen_blank(void)
 
     for (int x = 0; x < screen_get_width(); x++) {
         for (int y = 0; y < screen_get_height(); y++) {
-            CU_ASSERT_FALSE(screen_getpixel(x, y));
+            CU_ASSERT_FALSE(screen_get_pixel(x, y));
         }
     }
 
@@ -763,7 +763,7 @@ test_cpu_enable_extended_mode(void)
     setup();
     setup_cpu_screen_test();
 
-    CU_ASSERT_FALSE(screen_extended_mode);
+    CU_ASSERT_FALSE(screen_is_extended_mode());
 
     tword.WORD = 0x00FF;
     address.WORD = 0x0000;
@@ -771,7 +771,7 @@ test_cpu_enable_extended_mode(void)
     cpu.pc.WORD = 0x0000;
     cpu_execute_single();
 
-    CU_ASSERT_TRUE(screen_extended_mode);
+    CU_ASSERT_TRUE(screen_is_extended_mode());
 
     teardown();
     teardown_cpu_screen_test();
@@ -783,14 +783,14 @@ test_cpu_disable_extended_mode(void)
     setup();
     setup_cpu_screen_test();
 
-    screen_extended_mode = TRUE;
+    screen_mode = SCREEN_MODE_EXTENDED;
     tword.WORD = 0x00FE;
     address.WORD = 0x0000;
     memory_write_word(address, tword);
     cpu.pc.WORD = 0x0000;
     cpu_execute_single();
 
-    CU_ASSERT_FALSE(screen_extended_mode);
+    CU_ASSERT_FALSE(screen_is_extended_mode());
 
     teardown();
     teardown_cpu_screen_test();

--- a/src/globals.c
+++ b/src/globals.c
@@ -22,17 +22,13 @@ byte *memory;                  /**< Pointer to emulator memory region         */
 /* Screen */
 SDL_Surface *screen;           /**< Stores the main screen SDL structure      */
 SDL_Surface *virtscreen;       /**< Stores the Chip 8 virtual screen          */
-int screen_width;              /**< Stores the width of the screen in pixels  */
-int screen_height;             /**< Stores the height of the screen in pixels */
-int scale_factor;              /**< The scale factor applied to the screen    */
-int screen_extended_mode;      /**< Whether the screen is in extended mode    */
+int scale;                     /**< The scale factor applied to the screen    */
+int screen_mode;               /**< Whether the screen is in extended mode    */
+int scale_factor;              /**< Stores the current scale factor           */
 
 /* Colors */
 Uint32 COLOR_BLACK;            /**< Black pixel color                         */
 Uint32 COLOR_WHITE;            /**< White pixel color                         */
-Uint32 COLOR_DGREEN;           /**< Dark green pixel color (for overlay)      */
-Uint32 COLOR_LGREEN;           /**< Light green pixel color (for overlay)     */
-SDL_Color COLOR_TEXT;          /**< Text color (white)                        */
 
 /* CPU */
 chip8regset cpu;               /**< The main emulator CPU                     */

--- a/src/globals.h
+++ b/src/globals.h
@@ -25,12 +25,12 @@
 #define ROM_DEFAULT    0x200	   /**< Defines the default ROM load point      */
 
 /* Screen */
-#define SCREEN_HEIGHT      32    /**< Default screen height                   */
-#define SCREEN_WIDTH       64    /**< Default screen width                    */
-#define SCREEN_EXT_HEIGHT  64    /**< Extended screen height                  */
-#define SCREEN_EXT_WIDTH   128   /**< Extended screen width                   */
+#define SCREEN_HEIGHT      64    /**< Default screen height                   */
+#define SCREEN_WIDTH       128   /**< Default screen width                    */
 #define SCREEN_DEPTH       32    /**< Colour depth in BPP                     */
 #define SCALE_FACTOR       5     /**< Scaling for the window size             */
+#define SCREEN_MODE_NORMAL   0   /**< The normal screen mode                  */
+#define SCREEN_MODE_EXTENDED 1   /**< The extended screen mode                */
 #define PIXEL_COLOR        250   /**< Color to use for drawing pixels         */
 #define SCREEN_VERTREFRESH 60    /**< Sets the vertical refresh (in Hz)       */
 
@@ -98,17 +98,12 @@ extern byte *memory;                  /**< Pointer to emulator memory region    
 /* Screen */
 extern SDL_Surface *screen;           /**< Stores the main screen SDL structure      */
 extern SDL_Surface *virtscreen;       /**< Stores the Chip 8 virtual screen          */
-extern int screen_width;              /**< Stores the width of the screen in pixels  */
-extern int screen_height;             /**< Stores the height of the screen in pixels */
 extern int scale_factor;              /**< The scale factor applied to the screen    */
-extern int screen_extended_mode;      /**< Whether the screen is in extended mode    */
+extern int screen_mode;               /**< Whether the screen is in extended mode    */
 
 /* Colors */
 extern Uint32 COLOR_BLACK;            /**< Black pixel color                         */
 extern Uint32 COLOR_WHITE;            /**< White pixel color                         */
-extern Uint32 COLOR_DGREEN;           /**< Dark green pixel color (for overlay)      */
-extern Uint32 COLOR_LGREEN;           /**< Light green pixel color (for overlay)     */
-extern SDL_Color COLOR_TEXT;          /**< Text color (white)                        */
 
 /* CPU */
 extern chip8regset cpu;               /**< The main emulator CPU                     */
@@ -183,19 +178,21 @@ memory_write_word(register word address, register word value)
 
 /* screen.c */
 int screen_init(void);
+int screen_is_extended_mode(void);
 void screen_clear(SDL_Surface *surface, Uint32 color); 
 void screen_blank(void);
-int screen_getpixel(int x, int y);
+int screen_get_pixel(int x, int y);
 void screen_draw(int x, int y, int color);
 void screen_refresh(int overlay_on);
 void screen_destroy(void);
-void screen_set_extended(void);
-void screen_disable_extended(void);
+void screen_set_extended_mode(void);
+void screen_set_normal_mode(void);
 void screen_scroll_left(void);
 void screen_scroll_right(void);
 void screen_scroll_down(int num_pixels);
 int screen_get_height(void);
 int screen_get_width(void);
+int screen_get_mode_scale(void);
 
 /* keyboard.c */
 int keyboard_isemulatorkey(SDLKey key);
@@ -254,6 +251,9 @@ void test_screen_get_height_extended(void);
 void test_screen_scroll_right(void);
 void test_screen_scroll_left(void);
 void test_screen_scroll_down(void);
+void test_screen_get_mode_scale_normal(void);
+void test_screen_get_mode_scale_extended(void);
+void test_screen_is_mode_extended_correct(void);
 
 /* keyboard_test.c */
 void test_keyboard_checkforkeypress_returns_false_on_no_keypress(void);

--- a/src/screen_test.c
+++ b/src/screen_test.c
@@ -32,7 +32,7 @@ test_set_get_pixel(void)
 {
     setup_screen_test();
     screen_draw(10, 10, 1);
-    CU_ASSERT_TRUE(screen_getpixel(10, 10));
+    CU_ASSERT_TRUE(screen_get_pixel(10, 10));
     teardown_screen_test();
 }
 
@@ -42,7 +42,7 @@ test_set_pixel_color_zero_turns_pixel_off(void)
     setup_screen_test();
     screen_draw(10, 10, 1);
     screen_draw(10, 10, 0);
-    CU_ASSERT_FALSE(screen_getpixel(10, 10));
+    CU_ASSERT_FALSE(screen_get_pixel(10, 10));
     teardown_screen_test();
 }
 
@@ -61,7 +61,7 @@ test_screen_blank(void)
     screen_blank();
     for (x = 0; x < SCREEN_WIDTH; x++) {
         for (y = 0; y < SCREEN_HEIGHT; y++) {
-            CU_ASSERT_FALSE(screen_getpixel(x, y));
+            CU_ASSERT_FALSE(screen_get_pixel(x, y));
         }
     }
     teardown_screen_test();
@@ -71,8 +71,7 @@ void
 test_screen_get_width_normal(void)
 {
     setup_screen_test();
-    screen_extended_mode = FALSE;
-    CU_ASSERT_EQUAL(SCREEN_WIDTH, screen_get_width());
+    CU_ASSERT_EQUAL(64, screen_get_width());
     teardown_screen_test();
 }
 
@@ -80,8 +79,8 @@ void
 test_screen_get_width_extended(void)
 {
     setup_screen_test();
-    screen_extended_mode = TRUE;
-    CU_ASSERT_EQUAL(SCREEN_EXT_WIDTH, screen_get_width());
+    screen_set_extended_mode();
+    CU_ASSERT_EQUAL(128, screen_get_width());
     teardown_screen_test();
 }
 
@@ -89,8 +88,8 @@ void
 test_screen_get_height_normal(void)
 {
     setup_screen_test();
-    screen_extended_mode = FALSE;
-    CU_ASSERT_EQUAL(SCREEN_HEIGHT, screen_get_height());
+    screen_set_normal_mode();
+    CU_ASSERT_EQUAL(32, screen_get_height());
     teardown_screen_test();
 }
 
@@ -98,8 +97,8 @@ void
 test_screen_get_height_extended(void)
 {
     setup_screen_test();
-    screen_extended_mode = TRUE;
-    CU_ASSERT_EQUAL(SCREEN_EXT_HEIGHT, screen_get_height());
+    screen_set_extended_mode();
+    CU_ASSERT_EQUAL(64, screen_get_height());
     teardown_screen_test();
 }
 
@@ -107,12 +106,12 @@ void
 test_screen_scroll_right(void)
 {
     setup_screen_test();
-    screen_set_extended();
+    screen_set_extended_mode();
     screen_draw(1, 1, 1);
-    CU_ASSERT_TRUE(screen_getpixel(1, 1));
+    CU_ASSERT_TRUE(screen_get_pixel(1, 1));
     screen_scroll_right();
-    CU_ASSERT_FALSE(screen_getpixel(1, 1));
-    CU_ASSERT_TRUE(screen_getpixel(5, 1));
+    CU_ASSERT_FALSE(screen_get_pixel(1, 1));
+    CU_ASSERT_TRUE(screen_get_pixel(5, 1));
     teardown_screen_test();
 }
 
@@ -120,12 +119,12 @@ void
 test_screen_scroll_left(void)
 {
     setup_screen_test();
-    screen_set_extended();
+    screen_set_extended_mode();
     screen_draw(5, 1, 1);
-    CU_ASSERT_TRUE(screen_getpixel(5, 1));
+    CU_ASSERT_TRUE(screen_get_pixel(5, 1));
     screen_scroll_left();
-    CU_ASSERT_FALSE(screen_getpixel(5, 1));
-    CU_ASSERT_TRUE(screen_getpixel(1, 1));
+    CU_ASSERT_FALSE(screen_get_pixel(5, 1));
+    CU_ASSERT_TRUE(screen_get_pixel(1, 1));
     teardown_screen_test();
 }
 
@@ -133,13 +132,40 @@ void
 test_screen_scroll_down(void)
 {
     setup_screen_test();
-    screen_set_extended();
+    screen_set_extended_mode();
     screen_draw(1, 5, 1);
-    CU_ASSERT_TRUE(screen_getpixel(1, 5));
+    CU_ASSERT_TRUE(screen_get_pixel(1, 5));
     screen_scroll_down(4);
-    CU_ASSERT_FALSE(screen_getpixel(1, 5));
-    CU_ASSERT_TRUE(screen_getpixel(1, 9));
+    CU_ASSERT_FALSE(screen_get_pixel(1, 5));
+    CU_ASSERT_TRUE(screen_get_pixel(1, 9));
     teardown_screen_test();
+}
+
+void 
+test_screen_get_mode_scale_normal(void)
+{
+    setup_screen_test();
+    screen_set_normal_mode();
+    CU_ASSERT_EQUAL(2, screen_get_mode_scale());
+}
+
+void 
+test_screen_get_mode_scale_extended(void)
+{
+    setup_screen_test();
+    screen_set_extended_mode();
+    CU_ASSERT_EQUAL(1, screen_get_mode_scale());
+}
+
+void
+test_screen_is_mode_extended_correct(void)
+{
+    setup_screen_test();
+    screen_set_extended_mode();
+    CU_ASSERT_TRUE(screen_is_extended_mode());
+
+    screen_set_normal_mode();
+    CU_ASSERT_FALSE(screen_is_extended_mode());
 }
 
 /* E N D   O F   F I L E *****************************************************/

--- a/src/test.c
+++ b/src/test.c
@@ -87,7 +87,11 @@ main() {
         CU_add_test(screen_suite, "test_screen_get_height_extended", test_screen_get_height_extended) == NULL ||
         CU_add_test(screen_suite, "test_screen_scroll_right", test_screen_scroll_right) == NULL ||
         CU_add_test(screen_suite, "test_screen_scroll_left", test_screen_scroll_left) == NULL ||
-        CU_add_test(screen_suite, "test_screen_scroll_down", test_screen_scroll_down) == NULL)
+        CU_add_test(screen_suite, "test_screen_scroll_down", test_screen_scroll_down) == NULL ||
+        CU_add_test(screen_suite, "test_screen_get_mode_scale_normal", test_screen_get_mode_scale_normal) == NULL ||
+        CU_add_test(screen_suite, "test_screen_get_mode_scale_extended", test_screen_get_mode_scale_extended) == NULL ||
+        CU_add_test(screen_suite, "test_screen_is_mode_extended_correct", test_screen_is_mode_extended_correct) == NULL
+    )
     {
         CU_cleanup_registry();
         return CU_get_error();


### PR DESCRIPTION
This PR updates the screen drawing routines so that the size of the emulator window stays constant, regardless of whether the emulated screen resolution changes. This PR closes #36 