### PR TITLE
Add ability to load the pitch register and calculate playback rate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MAINOBJS = src/cpu.o src/keyboard.o src/memory.o src/screen.o src/yac8e.o src/gl
 TESTOBJS = src/cpu.o src/keyboard.o src/memory.o src/screen.o src/cpu_test.o src/screen_test.o src/test.o src/keyboard_test.o src/globals.o
 
 override CFLAGS += -Wall -g $(shell sdl-config --cflags)
-LDFLAGS += $(shell sdl-config --libs) -lcunit
+LDFLAGS += $(shell sdl-config --libs) -lcunit -lm
 
 .PHONY: all doc clean
 

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -9,6 +9,7 @@
 
 /* I N C L U D E S ************************************************************/
 
+#include <math.h>
 #include <time.h>
 #include "globals.h"
 
@@ -115,6 +116,8 @@ cpu_reset(void)
     }
     cpu.opdesc = (char *)malloc(MAXSTRSIZE);
     awaiting_keypress = FALSE;
+    playback_rate = 4000.0;
+    pitch = 64;
 }
 
 /******************************************************************************/
@@ -354,6 +357,10 @@ cpu_execute_single(void)
 
                 case 0x33:
                     store_bcd_in_memory();
+                    break;
+
+                case 0x3A:
+                    load_pitch();
                     break;
 
                 case 0x55:
@@ -1109,6 +1116,22 @@ store_bcd_in_memory(void)
     i = (cpu.v[x] % 100) % 10;
     memory_write(tword, i);
     sprintf(cpu.opdesc, "BCD V%X (%03d)", x, cpu.v[x]);
+}
+
+/******************************************************************************/
+
+/**
+ * Fx3A - Pitch Vx
+ * 
+ * Loads the value from register x into the pitch register.
+ */
+void
+load_pitch(void)
+{
+    int x = (cpu.operand.WORD & 0x0F00) >> 8;
+    pitch = cpu.v[x];
+    playback_rate = 4000.0 * pow(2.0, (((float) pitch - 64.0) / 48.0));
+    sprintf(cpu.opdesc, "PITCH V%X (%X)", x, cpu.v[x]);
 }
 
 /******************************************************************************/

--- a/src/cpu_test.c
+++ b/src/cpu_test.c
@@ -1209,6 +1209,32 @@ test_read_registers_from_rpl_integration(void)
     teardown();
 }
 
+void
+test_load_pitch(void)
+{
+    setup();
+    cpu.v[1] = 112;
+    cpu.operand.WORD = 0xF13A;
+    load_pitch();
+    CU_ASSERT_EQUAL(112, pitch);
+    CU_ASSERT_EQUAL(8000.0, playback_rate);    
+    teardown();
+}
+
+void
+test_load_pitch_integration(void)
+{
+    setup();
+    tword.WORD = 0xF13A;
+    memory_write_word(address, tword);
+    cpu.v[1] = 112;
+    cpu.pc.WORD = 0x0000;
+    cpu_execute_single();
+    CU_ASSERT_EQUAL(112, pitch);
+    CU_ASSERT_EQUAL(8000.0, playback_rate);    
+    teardown();  
+}
+
 void 
 test_return_from_subroutine(void)
 {
@@ -1223,6 +1249,7 @@ test_return_from_subroutine(void)
         return_from_subroutine();
         CU_ASSERT_EQUAL(a, cpu.pc.WORD);
     }
+    teardown();
 }
 
 void

--- a/src/globals.c
+++ b/src/globals.c
@@ -37,6 +37,8 @@ unsigned long cpu_interrupt;   /**< The CPU interrupt routine                 */
 int decrement_timers;          /**< Flags CPU to decrement DELAY and SOUND    */
 int op_delay;                  /**< Millisecond delay on the CPU              */
 int awaiting_keypress;         /**< Whether to wait for a keypress event      */
+float playback_rate;           /**< The playback rate for audio               */
+int pitch;                     /**< The pitch for the current audio sample    */
 
 /* Event captures */
 SDL_Event event;               /**< Stores SDL events                         */

--- a/src/globals.h
+++ b/src/globals.h
@@ -112,6 +112,8 @@ extern unsigned long cpu_interrupt;   /**< The CPU interrupt routine            
 extern int decrement_timers;          /**< Flags CPU to decrement DELAY and SOUND    */
 extern int op_delay;                  /**< Millisecond delay on the CPU              */
 extern int awaiting_keypress;         /**< Whether to wait for a keypress event      */
+extern float playback_rate;           /**< The playback rate for audio samples       */
+extern int pitch;                     /**< The pitch for the current audio sample    */
 
 /* Event captures */
 extern SDL_Event event;               /**< Stores SDL events                         */
@@ -169,6 +171,7 @@ void store_registers_in_memory(void);
 void load_registers_from_memory(void);
 void store_registers_in_rpl(void);
 void read_registers_from_rpl(void);
+void load_pitch(void);
 
 /* memory.c */
 int memory_init(int memorysize);
@@ -259,6 +262,8 @@ void test_store_registers_in_rpl(void);
 void test_store_registers_in_rpl_integration(void);
 void test_read_registers_from_rpl(void);
 void test_read_registers_from_rpl_integration(void);
+void test_load_pitch(void);
+void test_load_pitch_integration(void);
 void test_exit_interpreter(void);
 void test_cpu_scroll_left(void);
 void test_cpu_scroll_right(void);

--- a/src/test.c
+++ b/src/test.c
@@ -93,6 +93,8 @@ main() {
         CU_add_test(cpu_suite, "test_store_registers_in_rpl_integration", test_store_registers_in_rpl_integration) == NULL ||
         CU_add_test(cpu_suite, "test_read_registers_from_rpl", test_read_registers_from_rpl) == NULL ||
         CU_add_test(cpu_suite, "test_read_registers_from_rpl_integration", test_read_registers_from_rpl_integration) == NULL ||
+        CU_add_test(cpu_suite, "test_load_pitch", test_load_pitch) == NULL ||
+        CU_add_test(cpu_suite, "test_load_pitch_integration", test_load_pitch_integration) == NULL ||
         CU_add_test(cpu_suite, "test_return_from_subroutine", test_return_from_subroutine) == NULL ||
         CU_add_test(cpu_suite, "test_return_from_subroutine_integration", test_return_from_subroutine_integration) == NULL ||
         CU_add_test(cpu_suite, "test_exit_interpreter", test_exit_interpreter) == NULL ||


### PR DESCRIPTION
This PR adds the pitch register to the CPU and adds the ability to calculate the correct playback rate for an audio sample. Unit tests added to cover new functionality. This PR closes #22 