### PR TITLE
Implement jump_quirks flag

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2012-2019 Craig Thomas
+Copyright (C) 2012-2025 Craig Thomas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012-2024 Craig Thomas
+ * Copyright (C) 2012-2025 Craig Thomas
  * This project uses an MIT style license - see the LICENSE file for details.
  *
  * @file      cpu.c
@@ -904,8 +904,14 @@ load_index_with_value(void)
 void
 jump_to_register_plus_value(void)
 {
-    cpu.pc.WORD = (cpu.v[0] & 0xFF) + (cpu.operand.WORD & 0x0FFF);
-    sprintf(cpu.opdesc, "JUMP V0 + %03X", (cpu.operand.WORD & 0x0FFF));
+    if (jump_quirks) {
+        int x = (cpu.operand.WORD & 0x0F00) >> 8;
+        cpu.pc.WORD = cpu.v[x] + (cpu.operand.WORD & 0x00FF);
+        sprintf(cpu.opdesc, "JUMP V%X + %X", x, cpu.operand.WORD & 0x00FF);
+    } else {
+        cpu.pc.WORD = (cpu.v[0] & 0xFF) + (cpu.operand.WORD & 0x0FFF);
+        sprintf(cpu.opdesc, "JUMP V0 + %03X", (cpu.operand.WORD & 0x0FFF));
+    }
 }
 
 /******************************************************************************/

--- a/src/cpu_test.c
+++ b/src/cpu_test.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012-2019 Craig Thomas
+ * Copyright (C) 2012-2025 Craig Thomas
  * This project uses an MIT style license - see the LICENSE file for details.
  *
  * @file      cpu_test.c
@@ -18,6 +18,7 @@ void
 setup(void) 
 {
     CU_TEST_FATAL(memory_init(MEM_SIZE));
+    jump_quirks = FALSE;
     cpu_reset();
 }
 
@@ -783,6 +784,27 @@ test_jump_index_plus_value(void)
             CU_ASSERT_EQUAL(((index & 0xFF) + value) & 0xFFFF, cpu.pc.WORD);
         }
     }
+    teardown();
+}
+
+void
+test_jump_index_plus_value_jump_quirks(void)
+{
+    setup();
+    jump_quirks = TRUE;
+    for (int r = 0; r <= 0xF; r++) {
+        for (int index = 0; index < 0xFFF; index += 10) {
+            for (int value = 0; value < 0xFF; value += 10) {
+                cpu.v[r] = index;
+                cpu.pc.WORD = 0;
+                cpu.operand.WORD = value;
+                cpu.operand.WORD |= (r << 8);
+                jump_to_register_plus_value();
+                CU_ASSERT_EQUAL(((index & 0xFF) + value), cpu.pc.WORD);
+            }
+        }
+    }
+    teardown();
 }
 
 void

--- a/src/globals.c
+++ b/src/globals.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012-2024 Craig Thomas
+ * Copyright (C) 2012-2025 Craig Thomas
  * This project uses an MIT style license - see the LICENSE file for details.
  *
  * @file      globals.h
@@ -42,5 +42,8 @@ int pitch;                     /**< The pitch for the current audio sample    */
 
 /* Event captures */
 SDL_Event event;               /**< Stores SDL events                         */
+
+/* Emulator flags */
+int jump_quirks;               /**< Stores whether jump quirks are turned on  */
 
 /* E N D   O F   F I L E ******************************************************/

--- a/src/globals.h
+++ b/src/globals.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012-2024 Craig Thomas
+ * Copyright (C) 2012-2025 Craig Thomas
  * This project uses an MIT style license - see the LICENSE file for details.
  *
  * @file      globals.h
@@ -117,6 +117,9 @@ extern int pitch;                     /**< The pitch for the current audio sampl
 
 /* Event captures */
 extern SDL_Event event;               /**< Stores SDL events                         */
+
+/* Emulator flags */
+extern int jump_quirks;               /**< Stores whether jump quirks are turned on  */
 
 /* Test variables */
 extern word tword;
@@ -242,6 +245,7 @@ void test_shift_register_left_integration(void);
 void test_load_index(void);
 void test_load_index_integration(void);
 void test_jump_index_plus_value(void);
+void test_jump_index_plus_value_jump_quirks(void);
 void test_jump_index_plus_value_integration(void);
 void test_generate_random(void);
 void test_load_delay_into_target(void);

--- a/src/test.c
+++ b/src/test.c
@@ -71,6 +71,7 @@ main() {
         CU_add_test(cpu_suite, "test_load_index", test_load_index) == NULL ||
         CU_add_test(cpu_suite, "test_load_index_integration", test_load_index_integration) == NULL ||
         CU_add_test(cpu_suite, "test_jump_index_plus_value", test_jump_index_plus_value) == NULL ||
+        CU_add_test(cpu_suite, "test_jump_index_plus_value_jump_quirks", test_jump_index_plus_value_jump_quirks) == NULL ||
         CU_add_test(cpu_suite, "test_jump_index_plus_value_integration", test_jump_index_plus_value_integration) == NULL ||
         CU_add_test(cpu_suite, "test_generate_random", test_generate_random) == NULL ||
         CU_add_test(cpu_suite, "test_load_delay_into_target", test_load_delay_into_target) == NULL ||


### PR DESCRIPTION
This PR adds the `jump_quirks` flag to the emulator. The argument parsing routine was updated to use the `getopt` routines to get long options instead of short ones. Unit tests added to cover new functionality. This PR closes #28 