### PR TITLE
Implement shift_quirks

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -814,8 +814,14 @@ shift_right(void)
 {
     int x = (cpu.operand.WORD & 0x0F00) >> 8;
     int y = (cpu.operand.WORD & 0x00F0) >> 4;
-    int bit_one = cpu.v[y] & 0x1;
-    cpu.v[x] = cpu.v[y] >> 1;
+    int bit_one;
+    if (shift_quirks) {
+        bit_one = cpu.v[x] & 0x1;
+        cpu.v[x] = (cpu.v[x] >> 1);
+    } else {
+        bit_one = cpu.v[y] & 0x1;
+        cpu.v[x] = cpu.v[y] >> 1;
+    }
     cpu.v[0xF] = bit_one;
     sprintf(cpu.opdesc, "SHR V%X", x);
 }
@@ -853,8 +859,14 @@ shift_left(void)
 {
     int x = (cpu.operand.WORD & 0x0F00) >> 8;
     int y = (cpu.operand.WORD & 0x00F0) >> 4;
-    int bit_seven = (cpu.v[y] & 0x80) >> 7;
-    cpu.v[x] = (cpu.v[y] << 1) & 0xFF;
+    int bit_seven;
+    if (shift_quirks) {
+        bit_seven = (cpu.v[x] & 0x80) >> 7;
+        cpu.v[x] = (cpu.v[x] << 1) & 0xFF;
+    } else {
+        bit_seven = (cpu.v[y] & 0x80) >> 7;
+        cpu.v[x] = (cpu.v[y] << 1) & 0xFF;
+    }
     cpu.v[0xF] = bit_seven;
     sprintf(cpu.opdesc, "SHL V%X", x);
 }

--- a/src/cpu_test.c
+++ b/src/cpu_test.c
@@ -19,6 +19,7 @@ setup(void)
 {
     CU_TEST_FATAL(memory_init(MEM_SIZE));
     jump_quirks = FALSE;
+    shift_quirks = FALSE;
     cpu_reset();
 }
 
@@ -570,6 +571,27 @@ test_shift_register_right(void)
             }
         }
     }
+    teardown();
+}
+
+void
+test_shift_register_right_quirks(void)
+{
+    setup();
+    shift_quirks = TRUE;
+    for (int x = 0; x < 0xF; x++) {
+        for (int value = 0; value < 256; value++) {
+            cpu.operand.WORD = x << 8;
+            cpu.v[x] = (short) value;
+            short shifted_val = (short) (value >> 1);
+            short bit_zero = (short) (cpu.v[x] & 0x1);
+            cpu.v[0xF] = (short) 0;
+            shift_right();
+            CU_ASSERT_EQUAL(shifted_val, cpu.v[x]);
+            CU_ASSERT_EQUAL(bit_zero, cpu.v[0xF]);
+        }
+    }
+    teardown();
 }
 
 void
@@ -674,6 +696,27 @@ test_shift_register_left(void)
             }
         }
     }
+    teardown();
+}
+
+void
+test_shift_register_left_quirks(void)
+{
+    setup();
+    shift_quirks = TRUE;
+    for (int x = 0; x < 0xF; x++) {
+        for (int value = 0; value < 256; value++) {
+            cpu.v[x] = value;
+            cpu.operand.WORD = x << 8;
+            short bit_seven = ((value & 0x80) >> 7);
+            short shifted_val = ((value << 1) & 0xFF);
+            cpu.v[0xF] = 0;
+            shift_left();
+            CU_ASSERT_EQUAL(shifted_val, cpu.v[x]);
+            CU_ASSERT_EQUAL(bit_seven, cpu.v[0xF]);
+        }
+    }
+    teardown();
 }
 
 void

--- a/src/globals.c
+++ b/src/globals.c
@@ -45,5 +45,6 @@ SDL_Event event;               /**< Stores SDL events                         */
 
 /* Emulator flags */
 int jump_quirks;               /**< Stores whether jump quirks are turned on  */
+int shift_quirks;              /**< Stores whether shift quirks are turned on */
 
 /* E N D   O F   F I L E ******************************************************/

--- a/src/globals.h
+++ b/src/globals.h
@@ -120,6 +120,7 @@ extern SDL_Event event;               /**< Stores SDL events                    
 
 /* Emulator flags */
 extern int jump_quirks;               /**< Stores whether jump quirks are turned on  */
+extern int shift_quirks;              /**< Stores whether shift quirks are turned on */
 
 /* Test variables */
 extern word tword;
@@ -237,10 +238,12 @@ void test_add_register_to_register_integration(void);
 void test_sub_register_from_register(void);
 void test_sub_register_from_register_integration(void);
 void test_shift_register_right(void);
+void test_shift_register_right_quirks(void);
 void test_shift_register_right_integration(void);
 void test_sub_register_from_register_source_from_target(void);
 void test_sub_register_from_register_source_from_target_integration(void);
 void test_shift_register_left(void);
+void test_shift_register_left_quirks(void);
 void test_shift_register_left_integration(void);
 void test_load_index(void);
 void test_load_index_integration(void);

--- a/src/test.c
+++ b/src/test.c
@@ -63,10 +63,12 @@ main() {
         CU_add_test(cpu_suite, "test_sub_register_from_register", test_sub_register_from_register) == NULL ||
         CU_add_test(cpu_suite, "test_sub_register_from_register_integration", test_sub_register_from_register_integration) == NULL ||
         CU_add_test(cpu_suite, "test_shift_register_right", test_shift_register_right) == NULL ||
+        CU_add_test(cpu_suite, "test_shift_register_right_quirks", test_shift_register_right_quirks) == NULL ||
         CU_add_test(cpu_suite, "test_shift_register_right_integration", test_shift_register_right) == NULL ||
         CU_add_test(cpu_suite, "test_sub_register_from_register_source_from_target", test_sub_register_from_register_source_from_target) == NULL ||
         CU_add_test(cpu_suite, "test_sub_register_from_register_source_from_target_integration", test_sub_register_from_register_source_from_target_integration) == NULL ||
         CU_add_test(cpu_suite, "test_shift_register_left", test_shift_register_left) == NULL ||
+        CU_add_test(cpu_suite, "test_shift_register_left_quirks", test_shift_register_left_quirks) == NULL ||
         CU_add_test(cpu_suite, "test_shift_register_left_integration", test_shift_register_left_integration) == NULL ||
         CU_add_test(cpu_suite, "test_load_index", test_load_index) == NULL ||
         CU_add_test(cpu_suite, "test_load_index_integration", test_load_index_integration) == NULL ||

--- a/src/yac8e.c
+++ b/src/yac8e.c
@@ -62,7 +62,7 @@ loadrom(char *romfilename, int offset)
 void 
 print_help(void) 
 {
-    printf("usage: yac8e [-h] [-s] [-j] ROM\n\n");
+    printf("usage: yac8e [-h] [-s] [-S] [-j] ROM\n\n");
     printf("Starts a simple Chip 8 emulator. See README.md for more ");
     printf("information, and\nLICENSE for terms of use.\n\n");
     printf("positional arguments:\n");
@@ -71,6 +71,7 @@ print_help(void)
     printf("  -h, --help         show this help message and exit\n");
     printf("  -s, --scale N      scales the display by a factor of N\n");
     printf("  -j, --jump_quirks  enables jump quirks\n");
+    printf("  -S, --shift_quirks enables shift quirks\n");
 }
 
 /******************************************************************************/
@@ -86,17 +87,19 @@ char *
 parse_options(int argc, char **argv) 
 {
     jump_quirks = FALSE;
+    shift_quirks = FALSE;
     scale_factor = SCALE_FACTOR;
     op_delay = 0;
 
     int option_index = 0;
-    const char *short_options = ":hjs:";
+    const char *short_options = ":hjSs:";
     static struct option long_options[] =
     {
-        {"help",        no_argument,       NULL, 'h'},
-        {"jump_quirks", no_argument,       NULL, 'j'},
-        {"scale",       required_argument, NULL, 's'},
-        {NULL,          0,                 NULL,   0}
+        {"help",         no_argument,       NULL, 'h'},
+        {"jump_quirks",  no_argument,       NULL, 'j'},
+        {"shift_quirks", no_argument,       NULL, 'S'},
+        {"scale",        required_argument, NULL, 's'},
+        {NULL,           0,                 NULL,   0}
     };
 
     while (TRUE) {
@@ -123,6 +126,10 @@ parse_options(int argc, char **argv)
 
             case 'j':
                 jump_quirks = TRUE;
+                break;
+
+            case 'S':
+                shift_quirks = TRUE;
                 break;
 
             default:


### PR DESCRIPTION
This PR implements the `shift_quirks` flags in the emulator. Unit tests added to catch new functionality. This PR closes #26 