### PR TITLE
Implement additional colors for bitplanes

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -27,8 +27,10 @@ int screen_mode;               /**< Whether the screen is in extended mode    */
 int scale_factor;              /**< Stores the current scale factor           */
 
 /* Colors */
-Uint32 COLOR_BLACK;            /**< Black pixel color                         */
-Uint32 COLOR_WHITE;            /**< White pixel color                         */
+Uint32 COLOR_0;                /**< Bitplane 0 color                          */
+Uint32 COLOR_1;                /**< Bitplane 1 color                          */
+Uint32 COLOR_2;                /**< Bitplane 2 color                          */
+Uint32 COLOR_3;                /**< Bitplane 3 color                          */
 
 /* CPU */
 chip8regset cpu;               /**< The main emulator CPU                     */

--- a/src/globals.h
+++ b/src/globals.h
@@ -102,8 +102,10 @@ extern int scale_factor;              /**< The scale factor applied to the scree
 extern int screen_mode;               /**< Whether the screen is in extended mode    */
 
 /* Colors */
-extern Uint32 COLOR_BLACK;            /**< Black pixel color                         */
-extern Uint32 COLOR_WHITE;            /**< White pixel color                         */
+Uint32 COLOR_0;                       /**< Bitplane 0 color                          */
+Uint32 COLOR_1;                       /**< Bitplane 1 color                          */
+Uint32 COLOR_2;                       /**< Bitplane 2 color                          */
+Uint32 COLOR_3;                       /**< Bitplane 3 color                          */
 
 /* CPU */
 extern chip8regset cpu;               /**< The main emulator CPU                     */

--- a/src/globals.h
+++ b/src/globals.h
@@ -102,10 +102,10 @@ extern int scale_factor;              /**< The scale factor applied to the scree
 extern int screen_mode;               /**< Whether the screen is in extended mode    */
 
 /* Colors */
-Uint32 COLOR_0;                       /**< Bitplane 0 color                          */
-Uint32 COLOR_1;                       /**< Bitplane 1 color                          */
-Uint32 COLOR_2;                       /**< Bitplane 2 color                          */
-Uint32 COLOR_3;                       /**< Bitplane 3 color                          */
+extern Uint32 COLOR_0;                /**< Bitplane 0 color                          */
+extern Uint32 COLOR_1;                /**< Bitplane 1 color                          */
+extern Uint32 COLOR_2;                /**< Bitplane 2 color                          */
+extern Uint32 COLOR_3;                /**< Bitplane 3 color                          */
 
 /* CPU */
 extern chip8regset cpu;               /**< The main emulator CPU                     */

--- a/src/screen.c
+++ b/src/screen.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Craig Thomas
+ * Copyright (C) 2012-2025 Craig Thomas
  * This project uses an MIT style license - see the LICENSE file for details.
  *
  * @file      screen.c
@@ -23,14 +23,16 @@
 /* F U N C T I O N S **********************************************************/
 
 /**
- * Attempts to initialize the colors WHITE and BLACK. Does so by mapping RGB
- * values based upon the screen format. 
+ * Attempts to initialize the 4 colors used by the emulator to draw to the 
+ * screen.
  */
 void 
 init_colors(SDL_Surface *surface) 
 {
-    COLOR_BLACK = SDL_MapRGB(surface->format, 0, 0, 0);
-    COLOR_WHITE = SDL_MapRGB(surface->format, 250, 250, 250);
+    COLOR_0 = SDL_MapRGB(surface->format, 0, 0, 0);
+    COLOR_1 = SDL_MapRGB(surface->format, 250, 51, 204);
+    COLOR_2 = SDL_MapRGB(surface->format, 51, 204, 250);
+    COLOR_3 = SDL_MapRGB(surface->format, 250, 250, 250);
 }
 
 /******************************************************************************/
@@ -58,7 +60,7 @@ screen_get_pixel(int x, int y)
     Uint32 pixel = pixels[(virtscreen->w * y) + x];
     SDL_GetRGB(pixel, virtscreen->format, &r, &g, &b);
     color = SDL_MapRGB(virtscreen->format, r, g, b);
-    return color == COLOR_WHITE;
+    return color == COLOR_3;
 }
 
 /******************************************************************************/
@@ -104,7 +106,7 @@ screen_blit_surface(SDL_Surface *src, SDL_Surface *dest, int x, int y)
 void 
 screen_blank(void)
 {
-    screen_clear(virtscreen, COLOR_BLACK);
+    screen_clear(virtscreen, COLOR_0);
 }
 
 /******************************************************************************/
@@ -151,7 +153,7 @@ void
 screen_draw(int x, int y, int color)
 {
     SDL_Rect pixel;
-    Uint32 pixelcolor = COLOR_BLACK;
+    Uint32 pixelcolor = COLOR_0;
 
     int mode_scale = screen_get_mode_scale();
     pixel.x = x * scale_factor * mode_scale;
@@ -159,7 +161,7 @@ screen_draw(int x, int y, int color)
     pixel.w = scale_factor * mode_scale;
     pixel.h = scale_factor * mode_scale;
     if (color) {
-        pixelcolor = COLOR_WHITE;
+        pixelcolor = COLOR_3;
     }
     SDL_FillRect(virtscreen, &pixel, pixelcolor);
 }
@@ -219,7 +221,7 @@ screen_create_surface(int width, int height, int alpha, Uint32 color_key)
         if (color_key != -1) {
             SDL_SetColorKey(newsurface, SDL_SRCCOLORKEY, color_key);
         }
-        screen_clear(newsurface, COLOR_BLACK);
+        screen_clear(newsurface, COLOR_0);
     }
 
     return newsurface;


### PR DESCRIPTION
This PR adds the additional colors needed for drawing on bitplanes. Note that no draw instructions have been modified. The colors are newly defined, but unused. This PR closes #20 