### PR TITLE
Update to use libsdl2

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -10,8 +10,8 @@ jobs:
     - name: make test
       run: |
         sudo apt-get update
-        sudo apt-get install xvfb libcunit1 libcunit1-dev libcunit1-doc libsdl-image1.2-dev libsdl-mixer1.2-dev
-        sudo apt-get install libsdl-ttf2.0-dev libsdl1.2-dev libportmidi-dev libswscale-dev
+        sudo apt-get install xvfb libcunit1 libcunit1-dev libcunit1-doc 
+        sudo apt-get install libsdl2-dev libportmidi-dev libswscale-dev libsdl2-mixer-2.0-0 libsdl2-mixer-dev
         sudo apt-get install libavformat-dev libavcodec-dev libjpeg-dev libtiff5-dev libx11-6
         sudo apt-get install libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi
         sudo apt-get install libsmpeg-dev xfonts-cyrillic

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ TESTNAME = test
 MAINOBJS = src/cpu.o src/keyboard.o src/memory.o src/screen.o src/yac8e.o src/globals.o
 TESTOBJS = src/cpu.o src/keyboard.o src/memory.o src/screen.o src/cpu_test.o src/screen_test.o src/test.o src/keyboard_test.o src/globals.o
 
-override CFLAGS += -Wall -g $(shell sdl-config --cflags)
-LDFLAGS += $(shell sdl-config --libs) -lcunit -lm
+override CFLAGS += -Wall -g $(shell sdl2-config --cflags)
+LDFLAGS += $(shell sdl2-config --libs) -lcunit -lm
 
 .PHONY: all doc clean
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ the source, you will need the following required software packages:
 
 * [GNU C Compiler](http://gcc.gnu.org/) 4.6.3 or later
 * [GNU Make](http://www.gnu.org/software/make/) 3.81 or later
-* [SDL](http://www.libsdl.org/) 1.2.14 or later
+* [SDL](http://www.libsdl.org/) 2.0.20 or later
 * [CUnit](http://cunit.sourceforge.net/doc/index.html) 2.1-3 or later
 
 Note that other C compilers make work as well. To compile the project, open a

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -46,7 +46,7 @@ cpu_timerinit(void)
     SDL_InitSubSystem(SDL_INIT_TIMER);
     cpu_timer = SDL_AddTimer(17, cpu_timerinterrupt, NULL);
 
-    if (cpu_timer == NULL) {
+    if (cpu_timer == 0) {
         printf("Error: could not create timer: %s\n", SDL_GetError());
         result = FALSE;
     }
@@ -131,7 +131,7 @@ void
 cpu_process_sdl_events(void)
 {
     int emulatorkey;
-    SDLKey key;
+    SDL_KeyCode key;
 
     if (SDL_PollEvent(&event)) {
         switch (event.type) {

--- a/src/globals.c
+++ b/src/globals.c
@@ -20,8 +20,10 @@
 byte *memory;                  /**< Pointer to emulator memory region         */
 
 /* Screen */
-SDL_Surface *screen;           /**< Stores the main screen SDL structure      */
-SDL_Surface *virtscreen;       /**< Stores the Chip 8 virtual screen          */
+SDL_Window *window;            /**< Stores the main screen SDL structure      */
+SDL_Surface *surface;          /**< Stores the Chip 8 virtual screen          */
+SDL_Renderer *renderer;        /**< Stores the screen renderer                */
+SDL_Texture *texture;          /**< The SDL texture to render                 */
 int scale;                     /**< The scale factor applied to the screen    */
 int screen_mode;               /**< Whether the screen is in extended mode    */
 int scale_factor;              /**< Stores the current scale factor           */

--- a/src/globals.h
+++ b/src/globals.h
@@ -15,7 +15,8 @@
 
 /* I N C L U D E S ************************************************************/
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_keycode.h>
 
 /* D E F I N E S **************************************************************/
 
@@ -96,8 +97,10 @@ typedef struct {
 extern byte *memory;                  /**< Pointer to emulator memory region         */
 
 /* Screen */
-extern SDL_Surface *screen;           /**< Stores the main screen SDL structure      */
-extern SDL_Surface *virtscreen;       /**< Stores the Chip 8 virtual screen          */
+extern SDL_Window *window;            /**< Stores the main screen SDL structure      */
+extern SDL_Renderer *renderer;        /**< Stores the screen renderer                */
+extern SDL_Surface *surface;          /**< Stores the Chip 8 virtual screen          */
+extern SDL_Texture *texture;          /**< The SDL texture to render                 */
 extern int scale_factor;              /**< The scale factor applied to the screen    */
 extern int screen_mode;               /**< Whether the screen is in extended mode    */
 
@@ -195,7 +198,7 @@ void memory_destroy(void);
 /* screen.c */
 int screen_init(void);
 int screen_is_extended_mode(void);
-void screen_clear(SDL_Surface *surface, Uint32 color); 
+void screen_clear(Uint32 color); 
 void screen_blank(int bitplane);
 int get_pixel(int x, int y, int plane);
 void draw_pixel(int x, int y, int turn_on, int plane);
@@ -214,10 +217,10 @@ int screen_get_width(void);
 int screen_get_mode_scale(void);
 
 /* keyboard.c */
-int keyboard_isemulatorkey(SDLKey key);
+int keyboard_isemulatorkey(SDL_KeyCode key);
 int keyboard_checkforkeypress(int keycode);
-void keyboard_processkeydown(SDLKey key);
-void keyboard_processkeyup(SDLKey key);
+void keyboard_processkeydown(SDL_KeyCode key);
+void keyboard_processkeyup(SDL_KeyCode key);
 
 /* cpu_test.c */
 void test_return_from_subroutine(void);

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012-2024 Craig Thomas
+ * Copyright (C) 2012-2025 Craig Thomas
  * This project uses an MIT style license - see the LICENSE file for details.
  *
  * @file      keyboard.c
@@ -11,17 +11,12 @@
  * For example, key '0' will have a hex value of 0x0. Similarly, key 'A' will
  * have a hex value of 0xA. The keyboard routines use the SDL (Simple Direct
  * Media Layer) library to read the status of the keyboard. Because we don't
- * want to expose direct SDLKey values to the CPU, there are a number of 
- * routines that convert the SDLKey values to their associated hex values. 
+ * want to expose direct SDL_KeyCode values to the CPU, there are a number of 
+ * routines that convert the SDL_KeyCode values to their associated hex values. 
  *
  * The `keyboard_def` variable controls the mapping between the emulator keys
- * 0-9 and a-f to their associated SDLKey values. Change the mapping below if
+ * 0-9 and a-f to their associated SDL_KeyCode values. Change the mapping below if
  * you want to change the emulator keyboard.
- *
- * In addition to the emulator keys, there are two special keys, the 'ESC' and
- * 'F1' keys. Pressing 'F1' will place the emulator into a debug state where 
- * each operation will be displayed on STDOUT. The 'ESC' key will immediately
- * stop the emulator.
  */
 
 /* I N C L U D E S ************************************************************/
@@ -37,7 +32,7 @@
 /*!
  * Keyboard mapping from SDL keys to key values 
  */
-SDLKey keyboard_def[] = 
+SDL_KeyCode keyboard_def[] = 
 {
     SDLK_x,
     SDLK_1,
@@ -107,7 +102,7 @@ keyboard_checkforkeypress(int keycode)
  * @return the value of the key if it is an emulator key, -1 otherwise
  */
 int
-keyboard_isemulatorkey(SDLKey key)
+keyboard_isemulatorkey(SDL_KeyCode key)
 {
     for (int x=0; x < KEY_NUMBEROFKEYS; x++) {
         if (key == keyboard_def[x]) {
@@ -126,7 +121,7 @@ keyboard_isemulatorkey(SDLKey key)
  * @param key the SDLKey to process
  */
 void
-keyboard_processkeydown(SDLKey key) 
+keyboard_processkeydown(SDL_KeyCode key) 
 {
     for (int x=0; x < KEY_NUMBEROFKEYS; x++) {
         if (key == keyboard_def[x]) {
@@ -144,7 +139,7 @@ keyboard_processkeydown(SDLKey key)
  * @param key the SDLKey to process
  */
 void
-keyboard_processkeyup(SDLKey key) 
+keyboard_processkeyup(SDL_KeyCode key) 
 {
     for (int x=0; x < KEY_NUMBEROFKEYS; x++) {
         if (key == keyboard_def[x]) {


### PR DESCRIPTION
This PR updates the emulator to use SDL 2.0 instead of the deprecated SDL 1.2 interface. Most unit tests remain unaffected. Github Actions workflow updated to install correct libraries. This PR closes #51 