### PR TITLE
Fix for audio stack overflow

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -1286,7 +1286,7 @@ calculate_audio_waveform(void)
     // Re-sample the 128-bit audio buffer at the specified rate
     float position = 0.0f;
     float step = playback_rate / AUDIO_PLAYBACK_RATE;
-    byte new_buffer[2000];
+    Uint8 new_buffer[10000];
     ptr = 0;
 
     while (position < 128.0f) {


### PR DESCRIPTION
This PR fixes a problem with the stack buffer. In certain circumstances, the resampled buffer could overflow the static buffer allotted. The stack buffer was expanded and changed from generic `int` type to `Uint8`. 